### PR TITLE
fix bug: failed to call withdrawCoinWithAccountCap

### DIFF
--- a/src/libs/PTB/commonFunctions.ts
+++ b/src/libs/PTB/commonFunctions.ts
@@ -119,7 +119,13 @@ export async function withdrawCoinWithAccountCap(txb: TransactionBlock, _pool: P
     });
 
     // const [ret] = txb.moveCall({ target: `${config.ProtocolPackage}::lending::create_account` });
-    txb.transferObjects([ret], sender);
+    const [coin] = txb.moveCall({
+        target: `0x2::coin::from_balance`,
+        arguments: [txb.object(ret)],
+        typeArguments: [_pool.type]
+    });
+
+    txb.transferObjects([coin], sender);
 }
 
 /**


### PR DESCRIPTION
When calling the smart contract method incentive_v2::withdraw_with_account_cap, the returned result is of type Balance. It needs to be converted to type Coin before being transferred to the sender.