### PR TITLE
Update the USDC name to wUSDC and nUSDC in CoinInfo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-sdk",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/address.ts
+++ b/src/address.ts
@@ -241,13 +241,13 @@ export const AUSD: CoinInfo = {
 }
 
 export const wUSDC: CoinInfo = {
-    symbol: 'USDC',
+    symbol: 'wUSDC',
     address: '0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN',
     decimal: 6
 }
 
 export const nUSDC: CoinInfo = {
-    symbol: 'USDC',
+    symbol: 'nUSDC',
     address: '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC',
     decimal: 6
 }

--- a/src/libs/PTB/commonFunctions.ts
+++ b/src/libs/PTB/commonFunctions.ts
@@ -527,7 +527,7 @@ export async function getAvailableRewards(client: SuiClient, checkAddress: strin
         if (prettyPrint) {
             const coinDictionary: { [key: string]: string } = {
                 '0': 'Sui',
-                '1': 'USDC',
+                '1': 'wUSDC',
                 '2': 'USDT',
                 '3': 'WETH',
                 '4': 'CETUS',


### PR DESCRIPTION
Repay and withdraw function won't work now because `const coinSymbol = coinType.symbol ? coinType.symbol : coinType;` relies on the correct symbol name.