### PR TITLE
suiBTC (assetId 21) to parse correct DEEP rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-sdk",
-  "version": "1.4.28",
+  "version": "1.4.29",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/libs/PTB/commonFunctions.ts
+++ b/src/libs/PTB/commonFunctions.ts
@@ -514,6 +514,9 @@ export async function getAvailableRewards(client: SuiClient, checkAddress: strin
             if (assetId == '15' && pool.funds == '8e25210077ab957b1afec39cbe9165125c93d279daef89ee29b97856385a3f3e') {
                 assetId = '15extra' //Means DEEP Rewards
             }
+            if (assetId == '21' && pool.funds == '8e25210077ab957b1afec39cbe9165125c93d279daef89ee29b97856385a3f3e') {
+                assetId = '15extra' //Means DEEP Rewards
+            }
 
             const availableDecimal = (BigInt(pool.available) / BigInt(10 ** 27)).toString();
             


### PR DESCRIPTION
The suiBTC (wBTC) assetId 21 emits DEEP rewards.
<img width="197" alt="image" src="https://github.com/user-attachments/assets/aba1f132-b026-4e64-8fe0-c31ff30a645f" />

Therefore we need to map it correctly.

Otherwise the `getAvailableRewards()` functions would return 5.71689574 wBTC instead of 5716.89574 DEEP as rewards.