### PR TITLE
fix apy display wrong with decimal and add 5 rewardFundId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navi-sdk",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/address.ts
+++ b/src/address.ts
@@ -171,7 +171,7 @@ export const pool: { [key: string]: PoolConfig} = {
       "0x8fa5eccbca2c4ba9aae3b87fd44aa75aa5f5b41ea2d9be4d5321379384974984",
     supplyBalanceParentId:
       "0xe6457d247b6661b1cac123351998f88f3e724ff6e9ea542127b5dcb3176b3841",
-    rewardFundId: "",
+    rewardFundId: "0x7093cf7549d5e5b35bfde2177223d1050f71655c7f676a5e610ee70eb4d93b5c",
   },
   haSui: {
     name: "HaedalSui",
@@ -297,7 +297,7 @@ export const pool: { [key: string]: PoolConfig} = {
       "0x2c7b7e6d323ca8f63908bb03191225a2ecf177bf0c4602ccd21d7ac121d52fa4",
     supplyBalanceParentId:
       "0x071dc718b1e579d476d088456979e30d142ecdde6a6eec875477b5b4786530f0",
-      rewardFundId: "",
+      rewardFundId: "0xc6b14b4eda9015ca69ec5f6a9688faa4f760259ce285dafe902ebe6700f5838f",
   },
   LorenzoBTC: {
     name: "stBTC",
@@ -325,7 +325,7 @@ export const pool: { [key: string]: PoolConfig} = {
       "0xba03bb3e0167e1ec355926dfe0c130866857b062b93fb5d9cfba20824ad9f1d5",
     supplyBalanceParentId:
       "0x3fdd91f32dcea2af6e16ae66a7220f6439530ef6238deafe5a72026b3e7aa5f5",
-      rewardFundId: "",
+      rewardFundId: "0xc889d78b634f954979e80e622a2ae0fece824c0f6d9590044378a2563035f32f",
   },
   FDUSD: {
     name: "FDUSD",
@@ -339,7 +339,7 @@ export const pool: { [key: string]: PoolConfig} = {
       "0x4a4bb401f011c104083f56e3ee154266f1a88cad10b8acc9c993d4da304ebf00",
     supplyBalanceParentId:
       "0x6dffc3d05e79b055749eae1c27e93a47b5a9999214ce8a2f6173574151d120bf",
-      rewardFundId: "",
+      rewardFundId: "0x958dd7ad70755b10f96693bcd591d7a2cb9830a6c523baf43b3b5897664aa788",
   },
   BLUE: {
     name: "BLUE",

--- a/src/libs/PTB/V3.ts
+++ b/src/libs/PTB/V3.ts
@@ -774,8 +774,7 @@ export async function calculateApy(
       calculateRateSumAndCoins(supplyRules, coinPriceMap);
     const supplyApy = apyFormula(
       supplyRateSum,
-      (totalSupplyAmount * assetPrice.value) /
-        Math.pow(10, Number(assetPrice.decimals))
+      (totalSupplyAmount / Math.pow(10, Number(9)) * assetPrice.value )
     );
 
     // Calculate Borrow APY (option === 3)
@@ -784,8 +783,7 @@ export async function calculateApy(
       calculateRateSumAndCoins(borrowRules, coinPriceMap);
     const borrowApy = apyFormula(
       borrowRateSum,
-      (borrowedAmount * assetPrice.value) /
-        Math.pow(10, Number(assetPrice.decimals))
+      (borrowedAmount / Math.pow(10, Number(9)) * assetPrice.value)
     );
 
     return {
@@ -1136,7 +1134,6 @@ export async function getPoolsApy(
 
   // 6. Calculate APY using grouped incentive data and reserve data with price info
   const v3Apy = await calculateApy(groupedPools, reserves, coinPriceMap);
-
   // 7. Merge the APY results
   return mergeApyResults(v3Apy, v2SupplyApy, v2BorrowApy);
 }


### PR DESCRIPTION
1. The `getter::get_reserve_data` contract returns fields like `total_borrow`, `total_supply`, etc., with values standardized to a decimal precision of 9. Divide the denominator by 1e9 uniformly, without adjusting for decimals, and the APY was calculated correctly.
2. add 5 rewardFundId for VSUI，NAVX，SUINS，DEEP，FDUSD